### PR TITLE
Bugfix: onKeyDown() called instead of onKeyUp()

### DIFF
--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -297,10 +297,10 @@ class PanZoom extends React.Component<Props, State> {
   }
 
   onKeyUp = (e: SyntheticKeyboardEvent<HTMLDivElement>) => {
-    const { disableKeyInteraction, onKeyDown } = this.props
+    const { disableKeyInteraction, onKeyUp } = this.props
 
-    if (typeof onKeyDown === 'function') {
-        onKeyDown(e)
+    if (typeof onKeyUp === 'function') {
+        onKeyUp(e)
     }
 
     if (disableKeyInteraction) {


### PR DESCRIPTION
`onKeyDown()` is called both on key down and key up events, and `onKeyUp()` is never called...